### PR TITLE
feat: add scale definitions and interval maps with unit tests

### DIFF
--- a/lib/music/scales.test.ts
+++ b/lib/music/scales.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { SCALES, SCALE_NAMES } from "./scales";
+
+describe("SCALES", () => {
+    it("contains all 5 scale types", () => {
+        expect(SCALE_NAMES).toHaveLength(5);
+    });
+
+    it("major scale intervals are correct", () => {
+        expect(SCALES.major).toEqual([0, 2, 4, 5, 7, 9, 11]);
+    });
+
+    it("minor scale intervals are correct", () => {
+        expect(SCALES.minor).toEqual([0, 2, 3, 5, 7, 8, 10]);
+    });
+
+    it("pentatonic major scale intervals are correct", () => {
+        expect(SCALES.pentatonic_major).toEqual([0, 2, 4, 7, 9]);
+    });
+
+    it("pentatonic minor scale intervals are correct", () => {
+        expect(SCALES.pentatonic_minor).toEqual([0, 3, 5, 7, 10]);
+    });
+
+    it("dorian scale intervals are correct", () => {
+        expect(SCALES.dorian).toEqual([0, 2, 3, 5, 7, 9, 10]);
+    });
+});
+
+describe("SCALE_NAMES", () => {
+    it("is an array of all 5 scale types", () => {
+        expect(Array.isArray(SCALE_NAMES)).toBe(true);
+    });
+
+    it("includes major", () => {
+        expect(SCALE_NAMES).toContain("major");
+    });
+
+    it("includes minor", () => {
+        expect(SCALE_NAMES).toContain("minor");
+    });
+
+    it("includes pentatonic_major", () => {
+        expect(SCALE_NAMES).toContain("pentatonic_major");
+    });
+
+    it("includes pentatonic_minor", () => {
+        expect(SCALE_NAMES).toContain("pentatonic_minor");
+    });
+
+    it("includes dorian", () => {
+        expect(SCALE_NAMES).toContain("dorian");
+    });
+});

--- a/lib/music/scales.ts
+++ b/lib/music/scales.ts
@@ -1,0 +1,29 @@
+// A scale is defined by its intervals - the gaps between the notes.
+
+// Intervals are measured in semitones.
+// A semitone is one step in the chromatic scale — the smallest gap between two notes.
+// Example: C to C# = 1 semitone. C to D = 2 semitones.
+
+export type ScaleType =
+    | "major"
+    | "minor"
+    | "pentatonic_major"
+    | "pentatonic_minor"
+    | "dorian";
+
+// Each scale is an array of intervals from the root note.
+// The root note itself is always 0 (no distance from itself).
+//
+// Example — Major scale intervals: 0, 2, 4, 5, 7, 9, 11
+// Starting on C: C(0) D(2) E(4) F(5) G(7) A(9) B(11)
+// Those numbers are how many semitones each note is above the root.
+
+export const SCALES: Record<ScaleType, number[]> = {
+    major: [0, 2, 4, 5, 7, 9, 11],
+    minor: [0, 2, 3, 5, 7, 8, 10],
+    pentatonic_major: [0, 2, 4, 7, 9],
+    pentatonic_minor: [0, 3, 5, 7, 10],
+    dorian: [0, 2, 3, 5, 7, 9, 10],
+};
+
+export const SCALE_NAMES = Object.keys(SCALES) as ScaleType[];


### PR DESCRIPTION
## What does this PR do?
Added scale definitions for major, minor, pentatonic major, pentatonic minor & dorian along with unit tests cases testing their definitions and corresponding intervals

## Why?
visualizer needs to have the correct notes for a given scale - this will give the correct notes for given scale of various type (major, minor, ...)

## How to test
run the command "npm run test:run" all tests should pass

## Checklist
[x] No console.logs left
[x] TypeScript has no errors (npm run build)
[x] Looks good on mobile and desktop