### PR TITLE
feat: add getScaleNotes pure function with unit tests

### DIFF
--- a/lib/music/theory.test.ts
+++ b/lib/music/theory.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { getScaleNotes } from "./theory";
+
+describe("getScaleNotes", () => {
+    it("return C Major correctly", () => {
+        const notes = getScaleNotes("C", "major");
+        expect(notes).toEqual(["C", "D", "E", "F", "G", "A", "B"]);
+    });
+
+    it("return A Minor correctly", () => {
+        const notes = getScaleNotes("A", "minor");
+        expect(notes).toEqual(["A", "B", "C", "D", "E", "F", "G"]);
+    });
+
+    it("return A Pentatonic Minor correctly", () => {
+        const notes = getScaleNotes("A", "pentatonic_minor");
+        expect(notes).toEqual(["A", "C", "D", "E", "G"]);
+    });
+
+    it("always includes the root note as first note", () => {
+        expect(getScaleNotes("F", "major")[0]).toBe("F");
+        expect(getScaleNotes("G", "minor")[0]).toBe("G");
+        expect(getScaleNotes("D", "dorian")[0]).toBe("D");
+    });
+
+    it("returns correct number of notes per scale type", () => {
+        expect(getScaleNotes("C", "major")).toHaveLength(7);
+        expect(getScaleNotes("C", "minor")).toHaveLength(7);
+        expect(getScaleNotes("C", "dorian")).toHaveLength(7);
+        expect(getScaleNotes("C", "pentatonic_major")).toHaveLength(5);
+        expect(getScaleNotes("C", "pentatonic_minor")).toHaveLength(5);
+    });
+
+    it("handles root notes that cause wrapping", () => {
+        expect(getScaleNotes("G", "major")).toEqual([
+            "G",
+            "A",
+            "B",
+            "C",
+            "D",
+            "E",
+            "F#",
+        ]);
+    });
+});

--- a/lib/music/theory.ts
+++ b/lib/music/theory.ts
@@ -1,0 +1,17 @@
+import { CHROMATIC_SCALE, Note } from "./notes";
+import { SCALES, ScaleType } from "./scales";
+
+/**
+ *
+ * @param root - The root note of the scale.
+ * @param scale - The type of scale to get the notes for.
+ * @returns {Note[]} An array of notes in the scale.
+ */
+export function getScaleNotes(root: Note, scale: ScaleType): Note[] {
+    const rootIndex = CHROMATIC_SCALE.indexOf(root);
+    const intervals = SCALES[scale];
+    const notes = intervals.map((interval) => {
+        return CHROMATIC_SCALE[(rootIndex + interval) % 12];
+    });
+    return notes;
+}


### PR DESCRIPTION
## What does this PR do?
adds getScaleNotes() - Pure function that takes a root note and
scale type and returns the exact notes in that scale

## Why?
this completes the lib/music/ logic layer. Every other part of the visualizer (the store, fretboard) depends on this function being correct.

## How to test
npm run test:run - all tests in lib/music/theory.test.ts should pass,
including G Major wrapping test (verifies the % 12 modulo logic).

## Checklist
[x] No console.logs left
[x] TypeScript has no errors (npm run build)
[x] Looks good on mobile and desktop