### PR TITLE
feat: show guitar chord boxes on each chord card

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+GEMINI_API_KEY=your_gemini_api_key_here

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/app/chords/page.tsx
+++ b/app/chords/page.tsx
@@ -193,8 +193,8 @@ export default function Home() {
                                         </p>
                                     )}
 
-                                    <Card className="border-border bg-card flex self-center">
-                                        <CardContent className="flex justify-center gap-3">
+                                    <Card className="border-border bg-card flex self-center max-sm:w-full max-sm:py-0">
+                                        <CardContent className="flex justify-center gap-3 max-sm:block max-sm:p-4">
                                             <ChordPlayer
                                                 chordData={chordData}
                                                 bpm={bpm}
@@ -210,11 +210,13 @@ export default function Home() {
                                                 onChordChange={
                                                     setActiveChordIndex
                                                 }
-                                            />
-                                            <ExportButton
-                                                chordData={chordData}
-                                                bpm={bpm}
-                                                octave={octave}
+                                                actions={
+                                                    <ExportButton
+                                                        chordData={chordData}
+                                                        bpm={bpm}
+                                                        octave={octave}
+                                                    />
+                                                }
                                             />
                                         </CardContent>
                                     </Card>
@@ -288,8 +290,8 @@ export default function Home() {
                     </div>
 
                     {/* Floating input at bottom — width matches content; bar does not cover scrollbar */}
-                    <div className="absolute bottom-0 left-0 right-4 z-10 pl-4 pr-4 pb-4 pt-2 bg-background pointer-events-none">
-                        <div className="pointer-events-auto mx-auto max-w-2xl w-full">
+                    <div className="absolute bottom-0 left-0 right-0 z-10 px-4 pb-4 pt-2 bg-background pointer-events-none md:right-4">
+                        <div className="pointer-events-auto w-full md:mx-auto md:max-w-2xl">
                             <div className="flex items-center gap-2 rounded-2xl border border-input bg-background px-4 py-2.5 shadow-sm transition-colors focus-within:ring-2 focus-within:ring-ring focus-within:border-transparent min-w-0">
                                 <input
                                     ref={inputRef}

--- a/components/ChordBox.tsx
+++ b/components/ChordBox.tsx
@@ -1,0 +1,164 @@
+import type { GuitarChordBox } from "@/lib/guitarChordBox";
+
+interface ChordBoxProps {
+  chordBox: GuitarChordBox | null;
+}
+
+const STRING_X = [20, 36, 52, 68, 84, 100];
+const FRET_TOP = 32;
+const FRET_GAP = 20;
+const FRET_COUNT = 4;
+
+function fretCenterY(fret: number): number {
+  return FRET_TOP + (fret - 0.5) * FRET_GAP;
+}
+
+export default function ChordBox({ chordBox }: ChordBoxProps) {
+  if (!chordBox) {
+    return (
+      <div className="flex h-[150px] w-[120px] items-center justify-center rounded-md border border-dashed border-border text-center text-[10px] font-medium text-muted-foreground">
+        No guitar shape
+      </div>
+    );
+  }
+
+  const { position } = chordBox;
+  const barres = position.barres ?? [];
+
+  return (
+    <svg
+      viewBox="0 0 120 150"
+      role="img"
+      aria-label={`${chordBox.chord} guitar chord box`}
+      className="h-[150px] w-[120px] overflow-visible text-foreground"
+    >
+      {position.baseFret > 1 && (
+        <text
+          x="4"
+          y={fretCenterY(1) + 4}
+          className="fill-muted-foreground text-[9px] font-semibold"
+        >
+          {position.baseFret}fr
+        </text>
+      )}
+
+      {position.frets.map((fret, stringIndex) => {
+        const x = STRING_X[stringIndex];
+        if (fret === -1) {
+          return (
+            <text
+              key={`muted-${stringIndex}`}
+              x={x}
+              y="18"
+              textAnchor="middle"
+              className="fill-muted-foreground text-[12px] font-bold"
+            >
+              x
+            </text>
+          );
+        }
+
+        if (fret === 0) {
+          return (
+            <circle
+              key={`open-${stringIndex}`}
+              cx={x}
+              cy="14"
+              r="4"
+              className="fill-background stroke-muted-foreground"
+              strokeWidth="1.5"
+            />
+          );
+        }
+
+        return null;
+      })}
+
+      {Array.from({ length: FRET_COUNT + 1 }, (_, fretLine) => (
+        <line
+          key={`fret-${fretLine}`}
+          x1={STRING_X[0]}
+          x2={STRING_X[STRING_X.length - 1]}
+          y1={FRET_TOP + fretLine * FRET_GAP}
+          y2={FRET_TOP + fretLine * FRET_GAP}
+          className="stroke-muted-foreground"
+          strokeWidth={fretLine === 0 && position.baseFret === 1 ? 4 : 1.5}
+          strokeLinecap="round"
+        />
+      ))}
+
+      {STRING_X.map((x, stringIndex) => (
+        <line
+          key={`string-${stringIndex}`}
+          x1={x}
+          x2={x}
+          y1={FRET_TOP}
+          y2={FRET_TOP + FRET_COUNT * FRET_GAP}
+          className="stroke-muted-foreground"
+          strokeWidth={stringIndex === 0 ? 2 : 1.2}
+          strokeLinecap="round"
+        />
+      ))}
+
+      {barres.map((barreFret) => {
+        const barredStrings = position.frets
+          .map((fret, stringIndex) => ({ fret, stringIndex }))
+          .filter(({ fret }) => fret === barreFret);
+
+        if (barredStrings.length < 2) {
+          return null;
+        }
+
+        const firstString = Math.min(
+          ...barredStrings.map(({ stringIndex }) => stringIndex),
+        );
+        const lastString = Math.max(
+          ...barredStrings.map(({ stringIndex }) => stringIndex),
+        );
+        const x = STRING_X[firstString] - 7;
+        const width = STRING_X[lastString] - STRING_X[firstString] + 14;
+
+        return (
+          <rect
+            key={`barre-${barreFret}`}
+            x={x}
+            y={fretCenterY(barreFret) - 7}
+            width={width}
+            height="14"
+            rx="7"
+            className="fill-primary"
+          />
+        );
+      })}
+
+      {position.frets.map((fret, stringIndex) => {
+        if (fret <= 0) {
+          return null;
+        }
+
+        const finger = position.fingers[stringIndex];
+
+        return (
+          <g key={`finger-${stringIndex}-${fret}`}>
+            <circle
+              cx={STRING_X[stringIndex]}
+              cy={fretCenterY(fret)}
+              r="7"
+              className="fill-primary"
+            />
+            {finger > 0 && (
+              <text
+                x={STRING_X[stringIndex]}
+                y={fretCenterY(fret) + 3.5}
+                textAnchor="middle"
+                className="fill-primary-foreground text-[9px] font-bold"
+              >
+                {finger}
+              </text>
+            )}
+          </g>
+        );
+      })}
+    </svg>
+  );
+}

--- a/components/ChordCard.tsx
+++ b/components/ChordCard.tsx
@@ -9,6 +9,8 @@
 
 import { cn } from "@/lib/utils";
 import { Card, CardContent } from "@/components/ui/card";
+import ChordBox from "@/components/ChordBox";
+import { getGuitarChordBox } from "@/lib/guitarChordBox";
 
 interface ChordCardProps {
   chord: string;
@@ -17,16 +19,18 @@ interface ChordCardProps {
 }
 
 export default function ChordCard({ chord, index, isActive }: ChordCardProps) {
+  const chordBox = getGuitarChordBox(chord);
+
   return (
     <Card
       className={cn(
-        "min-w-[80px] transition-all duration-200 ease-out",
+        "min-w-[150px] transition-all duration-200 ease-out",
         isActive
           ? "border-primary bg-primary/15 scale-105 shadow-lg shadow-primary/20"
           : "border-border bg-card/80 hover:border-muted-foreground/30"
       )}
     >
-      <CardContent className="flex flex-col items-center justify-center gap-1 p-4">
+      <CardContent className="flex flex-col items-center justify-center gap-2 p-4">
         <span className="text-[11px] font-medium text-muted-foreground">
           {index + 1}
         </span>
@@ -38,6 +42,7 @@ export default function ChordCard({ chord, index, isActive }: ChordCardProps) {
         >
           {chord}
         </span>
+        <ChordBox chordBox={chordBox} />
       </CardContent>
     </Card>
   );

--- a/components/ChordPlayer.tsx
+++ b/components/ChordPlayer.tsx
@@ -32,7 +32,7 @@
  *    Otherwise we'd get ghost audio playing in the background.
  */
 
-import { useRef, useEffect, useCallback } from "react";
+import { useRef, useEffect, useCallback, type ReactNode } from "react";
 import { ChordData } from "@/types/chord";
 import { chordToNotes } from "@/lib/chordToNotes";
 import { Button } from "@/components/ui/button";
@@ -64,6 +64,8 @@ interface ChordPlayerProps {
   onPlayToggle: () => void;
   /** Called on each beat with the index of the chord now playing */
   onChordChange: (index: number) => void;
+  /** Optional action rendered with the player controls, like MIDI export. */
+  actions?: ReactNode;
 }
 
 const OCTAVE_MIN = 2;
@@ -113,6 +115,7 @@ export default function ChordPlayer({
   isPlaying,
   onPlayToggle,
   onChordChange,
+  actions,
 }: ChordPlayerProps) {
   /**
    * useRef stores mutable values that persist across renders without
@@ -282,23 +285,24 @@ export default function ChordPlayer({
   }, [chordData]); // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
-    <div className="flex items-center gap-3 flex-wrap">
-      <Button
-        onClick={onPlayToggle}
-        variant="default"
-        size="icon"
-        className="rounded-lg"
-        aria-label={isPlaying ? "Pause" : "Play"}
-        title={isPlaying ? "Pause" : "Play"}
-      >
-        {isPlaying ? (
-          <Pause className="size-5" aria-hidden />
-        ) : (
-          <Play className="size-5" aria-hidden />
-        )}
-      </Button>
+    <div className="flex items-center gap-3 flex-wrap max-sm:w-full max-sm:flex-col max-sm:items-stretch">
+      <div className="flex min-w-0 items-center gap-3 max-sm:w-full sm:contents">
+        <Button
+          onClick={onPlayToggle}
+          variant="default"
+          size="icon"
+          className="rounded-lg max-sm:size-10"
+          aria-label={isPlaying ? "Pause" : "Play"}
+          title={isPlaying ? "Pause" : "Play"}
+        >
+          {isPlaying ? (
+            <Pause className="size-5 max-sm:size-4" aria-hidden />
+          ) : (
+            <Play className="size-5 max-sm:size-4" aria-hidden />
+          )}
+        </Button>
 
-      <div className="flex min-w-80 max-w-80 flex-1 items-center gap-2">
+      <div className="flex min-w-80 max-w-80 flex-1 items-center gap-2 max-sm:min-w-0 max-sm:max-w-none max-sm:flex-1">
         <Label htmlFor="bpm-slider" className="w-8 shrink-0 text-muted-foreground text-xs">
           BPM
         </Label>
@@ -314,34 +318,38 @@ export default function ChordPlayer({
           {bpm}
         </span>
       </div>
-      {onOctaveChange && (
-        <div className="flex items-center gap-2">
-          <Label className="text-muted-foreground shrink-0 text-xs">Octave</Label>
-          <div className="flex items-center rounded-md border border-input bg-muted/30">
-            <button
-              type="button"
-              onClick={() => onOctaveChange(Math.max(OCTAVE_MIN, octave - 1))}
-              disabled={octave <= OCTAVE_MIN}
-              className="inline-flex size-8 items-center justify-center rounded-l-md text-muted-foreground hover:bg-muted hover:text-foreground cursor-pointer disabled:pointer-events-none disabled:opacity-50"
-              aria-label="Lower octave"
-            >
-              <ChevronDown className="size-4" />
-            </button>
-            <span className="min-w-8 text-center text-sm font-mono tabular-nums">
-              {octave}
-            </span>
-            <button
-              type="button"
-              onClick={() => onOctaveChange(Math.min(OCTAVE_MAX, octave + 1))}
-              disabled={octave >= OCTAVE_MAX}
-              className="inline-flex size-8 items-center justify-center rounded-r-md text-muted-foreground hover:bg-muted hover:text-foreground cursor-pointer disabled:pointer-events-none disabled:opacity-50"
-              aria-label="Raise octave"
-            >
-              <ChevronUp className="size-4" />
-            </button>
+      </div>
+      <div className="contents max-sm:flex max-sm:items-center max-sm:justify-end max-sm:gap-2">
+        {onOctaveChange && (
+          <div className="flex items-center gap-2">
+            <Label className="text-muted-foreground shrink-0 text-xs">Octave</Label>
+            <div className="flex items-center rounded-md border border-input bg-muted/30">
+              <button
+                type="button"
+                onClick={() => onOctaveChange(Math.max(OCTAVE_MIN, octave - 1))}
+                disabled={octave <= OCTAVE_MIN}
+                className="inline-flex size-8 items-center justify-center rounded-l-md text-muted-foreground hover:bg-muted hover:text-foreground cursor-pointer disabled:pointer-events-none disabled:opacity-50"
+                aria-label="Lower octave"
+              >
+                <ChevronDown className="size-4" />
+              </button>
+              <span className="min-w-8 text-center text-sm font-mono tabular-nums">
+                {octave}
+              </span>
+              <button
+                type="button"
+                onClick={() => onOctaveChange(Math.min(OCTAVE_MAX, octave + 1))}
+                disabled={octave >= OCTAVE_MAX}
+                className="inline-flex size-8 items-center justify-center rounded-r-md text-muted-foreground hover:bg-muted hover:text-foreground cursor-pointer disabled:pointer-events-none disabled:opacity-50"
+                aria-label="Raise octave"
+              >
+                <ChevronUp className="size-4" />
+              </button>
+            </div>
           </div>
-        </div>
-      )}
+        )}
+        {actions}
+      </div>
     </div>
   );
 }

--- a/lib/guitarChordBox.test.ts
+++ b/lib/guitarChordBox.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { getGuitarChordBox, parseGuitarChordSymbol } from "./guitarChordBox";
+
+describe("parseGuitarChordSymbol", () => {
+  it("parses root notes and suffixes", () => {
+    expect(parseGuitarChordSymbol("C")).toEqual({ root: "C", suffix: "" });
+    expect(parseGuitarChordSymbol("Bbmaj7")).toEqual({
+      root: "Bb",
+      suffix: "maj7",
+    });
+    expect(parseGuitarChordSymbol("F#m7b5")).toEqual({
+      root: "F#",
+      suffix: "m7b5",
+    });
+  });
+});
+
+describe("getGuitarChordBox", () => {
+  it("finds common major and minor chords", () => {
+    expect(getGuitarChordBox("C")?.suffix).toBe("major");
+    expect(getGuitarChordBox("Am")?.suffix).toBe("minor");
+  });
+
+  it("normalizes roots to keys used by chords-db", () => {
+    expect(getGuitarChordBox("A#")?.key).toBe("Bb");
+    expect(getGuitarChordBox("D#m")?.key).toBe("Eb");
+    expect(getGuitarChordBox("Dbmaj7")?.key).toBe("Csharp");
+  });
+
+  it("finds generated extended chords when available", () => {
+    expect(getGuitarChordBox("Cm9")?.suffix).toBe("m9");
+    expect(getGuitarChordBox("Fm11")?.suffix).toBe("m11");
+    expect(getGuitarChordBox("G7b9")?.suffix).toBe("7b9");
+    expect(getGuitarChordBox("Dm7b5")?.suffix).toBe("m7b5");
+  });
+
+  it("falls back to simpler playable shapes for unsupported suffixes", () => {
+    const chordBox = getGuitarChordBox("Abmaj7#11");
+
+    expect(chordBox?.key).toBe("Ab");
+    expect(chordBox?.suffix).toBe("maj7");
+    expect(chordBox?.position.frets).toHaveLength(6);
+  });
+
+  it("returns null for invalid chord symbols", () => {
+    expect(getGuitarChordBox("not a chord")).toBeNull();
+  });
+});

--- a/lib/guitarChordBox.ts
+++ b/lib/guitarChordBox.ts
@@ -1,0 +1,123 @@
+import guitarData from "@tombatossals/chords-db/lib/guitar.json";
+
+export interface GuitarChordPosition {
+  frets: number[];
+  fingers: number[];
+  baseFret: number;
+  barres: number[];
+  capo?: boolean;
+}
+
+export interface GuitarChordBox {
+  chord: string;
+  key: string;
+  suffix: string;
+  position: GuitarChordPosition;
+}
+
+interface GuitarChordDefinition {
+  key: string;
+  suffix: string;
+  positions: GuitarChordPosition[];
+}
+
+interface GuitarChordDatabase {
+  keys: string[];
+  suffixes: string[];
+  chords: Record<string, GuitarChordDefinition[]>;
+}
+
+const guitar = guitarData as GuitarChordDatabase;
+
+const ROOT_TO_DB_KEY: Record<string, string> = {
+  "A#": "Bb",
+  "C#": "Csharp",
+  Db: "Csharp",
+  "D#": "Eb",
+  "F#": "Fsharp",
+  Gb: "Fsharp",
+  "G#": "Ab",
+};
+
+const SUFFIX_ALIASES: Record<string, string> = {
+  "": "major",
+  M: "major",
+  maj: "major",
+  m: "minor",
+  min: "minor",
+  "+": "aug",
+};
+
+const SUFFIX_FALLBACKS: Record<string, string[]> = {
+  maj7: ["major"],
+  "maj7#11": ["maj7", "major"],
+  maj9: ["maj7", "major"],
+  maj11: ["maj7", "major"],
+  maj13: ["maj7", "major"],
+  m9: ["m7", "minor"],
+  m11: ["m7", "minor"],
+  m13: ["m7", "minor"],
+  "7b9": ["7", "major"],
+  "7#9": ["7", "major"],
+  "9#11": ["9", "7", "major"],
+  add9: ["major"],
+  madd9: ["minor"],
+};
+
+export function parseGuitarChordSymbol(
+  chordName: string,
+): { root: string; suffix: string } | null {
+  const match = chordName.trim().match(/^([A-G])([#b]?)(.*)$/);
+  if (!match) {
+    return null;
+  }
+
+  return {
+    root: match[1] + match[2],
+    suffix: match[3],
+  };
+}
+
+function toDatabaseKey(root: string): string {
+  return ROOT_TO_DB_KEY[root] ?? root;
+}
+
+function toDatabaseSuffix(suffix: string): string {
+  return SUFFIX_ALIASES[suffix] ?? suffix;
+}
+
+function suffixCandidates(suffix: string): string[] {
+  const databaseSuffix = toDatabaseSuffix(suffix);
+  return [databaseSuffix, ...(SUFFIX_FALLBACKS[databaseSuffix] ?? [])];
+}
+
+export function getGuitarChordBox(chordName: string): GuitarChordBox | null {
+  const parsed = parseGuitarChordSymbol(chordName);
+  if (!parsed) {
+    return null;
+  }
+
+  const key = toDatabaseKey(parsed.root);
+  const chordDefinitions = guitar.chords[key];
+  if (!chordDefinitions) {
+    return null;
+  }
+
+  for (const suffix of suffixCandidates(parsed.suffix)) {
+    const chord = chordDefinitions.find(
+      (definition) => definition.suffix === suffix,
+    );
+    const position = chord?.positions[0];
+
+    if (position) {
+      return {
+        chord: chordName,
+        key,
+        suffix,
+        position,
+      };
+    }
+  }
+
+  return null;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@google/generative-ai": "^0.24.1",
+        "@tombatossals/chords-db": "^0.5.1",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^0.576.0",
@@ -4905,6 +4906,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@tombatossals/chords-db": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@tombatossals/chords-db/-/chords-db-0.5.1.tgz",
+      "integrity": "sha512-5kLLtwOxmnFfpVTYfYiw1Q22NJ8msb5JeyDLre09XnUFx2l6KSeqPtJQPsVPOak4BUenlsv/j2H65KBVhB6qgQ==",
+      "license": "MIT"
     },
     "node_modules/@tonaljs/midi": {
       "version": "4.10.2",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@google/generative-ai": "^0.24.1",
+    "@tombatossals/chords-db": "^0.5.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.576.0",


### PR DESCRIPTION
## What does this PR do?
Adds guitar chord box diagrams to chord cards and improves the mobile layout for playback controls.

## Why?
Closes #10 Users should be able to quickly see how to play each generated chord, and the player controls should remain usable on smaller screens.

## How to test
- Generate or load a sample chord progression.
- Confirm each chord card shows a guitar chord shape.
- Check the playback controls on mobile and desktop widths.
- Confirm the prompt input spans correctly on mobile.
- Run `npm run build`.
- Run `npm run lint`.

## Checklist
[x] No console.logs left
[x] TypeScript has no errors (npm run build)
[x] Looks good on mobile and desktop